### PR TITLE
Move to Hopp-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.dll
 *.so
 *.dylib
-pwcli
+hopp-cli
 
 # Test binary, built with `go test -c`
 *.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,14 +38,14 @@ changelog:
       - '^test:'
 release:
   github:
-    owner: athul
-    name: pwcli
+    owner: hoppscotch
+    name: hopp-cli
 brews:
-  - name: pwcli
+  - name: hopp-cli
     github:
       owner: athul
       name: homebrew-tap
     folder: Formula
-    homepage: 'https://github.com/athul/pwcli'
-    description: 'Postwoman CLI in Go'
-    install: bin.install "pwcli"
+    homepage: 'https://github.com/hoppscotch/hopp-cli'
+    description: 'CLI for Hoppscotch.io'
+    install: bin.install "hopp-cli"

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ BINDIR?=$(PREFIX)/bin
 VERSION?=$(shell git tag | grep ^v | sort -V | tail -n 1)
 GOFLAGS?=-ldflags '-X main.VERSION=${VERSION}'
 
-pwcli: cli.go go.mod go.sum
+hopp-cli: cli.go go.mod go.sum
 	@echo
-	@echo Building pwcli. This may take a minute or two.
+	@echo Building hopp-cli. This may take a minute or two.
 	@echo
 	go build $(GOFLAGS) -o $@
 	@echo
@@ -32,17 +32,17 @@ update:
 .PHONY: install
 install:
 	@echo
-	@echo Installing pwcli...
+	@echo Installing hopp-cli...
 	@echo
-	install -m755 pwcli $(BINDIR)
+	install -m755 hopp-cli $(BINDIR)
 	@echo
 	@echo ...Done\!
 
 .PHONY: uninstall
 uninstall:
 	@echo
-	@echo Uninstalling pwcli...
+	@echo Uninstalling hopp-cli...
 	@echo
-	rm -f $(BINDIR)/pwcli
+	rm -f $(BINDIR)/hopp-cli
 	@echo
 	@echo ...Done\!

--- a/cli.go
+++ b/cli.go
@@ -123,7 +123,7 @@ func main() {
 
 	WE REALLY NEED YOUR FEEDBACK, 
 
-	CREATE A NEW ISSUE FOR BUGS AND FEATURE REQUESTS : < http://github.com/athul/pwcli >
+	CREATE A NEW ISSUE FOR BUGS AND FEATURE REQUESTS : < https://github.com/hoppscotch/hopp-cli >
 	
 	`, cli.AppHelpTemplate)
 


### PR DESCRIPTION
This PR will change the name of `pwcli` to `hopp-cli`. This doesn't change the functionality nor basic working, just the name. Close #15 