### PR TITLE
Revise Help message 🍣

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -119,12 +119,12 @@ func main() {
 			},
 		},
 	}
-	cli.AppHelpTemplate = fmt.Sprintf(`%sS
+	cli.AppHelpTemplate = fmt.Sprintf(`%s
 
-	WE REALLY NEED YOUR FEEDBACK, 
+	WE REALLY NEED YOUR FEEDBACK,
 
 	CREATE A NEW ISSUE FOR BUGS AND FEATURE REQUESTS : < https://github.com/hoppscotch/hopp-cli >
-	
+
 	`, cli.AppHelpTemplate)
 
 	err := app.Run(os.Args)

--- a/cli.go
+++ b/cli.go
@@ -15,10 +15,10 @@ var VERSION = ""
 
 func main() {
 	app := cli.NewApp()
-	app.Name = color.HiGreenString("Postwoman CLI")
+	app.Name = color.HiGreenString("Hoppscotch CLI")
 	app.Version = color.HiRedString(VERSION)
 	app.Usage = color.HiYellowString("Test API endpoints without the hassle")
-	app.Description = color.HiBlueString("Made with <3 by Postwoman Team")
+	app.Description = color.HiBlueString("Made with <3 by Hoppscotch Team")
 
 	var out string
 
@@ -111,7 +111,7 @@ func main() {
 		},
 		{
 			Name:  "send",
-			Usage: "Test all the Endpoints in the Postwoman Collection.json",
+			Usage: "Test all the Endpoints in the Hoppscotch Collection.json",
 			Action: func(c *cli.Context) error {
 				var err error
 				out, err = mets.ReadCollection(c)


### PR DESCRIPTION
## Why?
- On viewing help option or without options, there is an unnecessary `S` on help message.

![Screen Shot 2020-10-07 at 15 07 09](https://user-images.githubusercontent.com/2187465/95296528-e3dcd200-08b3-11eb-8b45-31c4c20b49d1.png)

## How?
- Just removed `S`. 🍣 
- Change `Postwoman` to `Hoppscotch` on the help message

❤️ 
![Screen Shot 2020-10-07 at 17 02 06](https://user-images.githubusercontent.com/2187465/95304163-29eb6300-08bf-11eb-83c2-498c76559ee5.png)

