### PR TITLE
Request body from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,22 @@ _(optional)_
 |`html`|`text/html`|
 |`xml`|`application/xml`|
 |`plain`|`text/plain`|
+
+### Providing a Request Body via stdin
+
+In addition to `-b`/`--body`, you may provide a request body via stdin.
+If you combine this method with the `-b` flag, the body provided with `-b` will be ignored.
+
+**Example with Pipes**
+```shell
+$ echo '{"foo":"bar"}' | hopp-cli post -c js http://example.com
+```
+**Example with Redirection**
+```shell
+$ cat myrequest.json
+{
+  "foo": "bar"
+}
+
+$ hopp-cli post -c js http://example.com <myrequest.json
+```

--- a/methods/basic.go
+++ b/methods/basic.go
@@ -3,7 +3,9 @@ package methods
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/urfave/cli"
 )
@@ -15,8 +17,23 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 		return "", err
 	}
 
-	var jsonStr = []byte(c.String("body"))
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(jsonStr))
+	// Check if we're being passed a request body from stdin.
+	// If so, use that. Otherwise, use the request data passed via cli flag.
+	var body []byte
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return "", fmt.Errorf("error getting file info for stdin fd: %w", err)
+	}
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		body, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("error reading from stdin: %w", err)
+		}
+	} else {
+		body = []byte(c.String("body"))
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return "", fmt.Errorf("Error creating request: %s", err.Error())
 	}


### PR DESCRIPTION
I thought this would be a handy addition. It will also make requests with a body more easily scriptable.

* Checks if data is being passed via `stdin`, and if so, uses it as the request body (and ignores `-b / --body`). This does not try to guess the content-type, it only replaces the `-b` flag.
* If data is not being passed via stdin, use whatever is being passed via `-b` (or nothing if the flag is omitted).

Example with redirection:
```
$ cat myrequest.json
{
  "foo": "bar"
}

$ hopp-cli post -c js http://example.com <myrequest.json
```

Example with pipes:
```
$ echo '{"foo":"bar"}' | hopp-cli post -c js http://example.com
```

If you combine `stdin` and `-b`, then `-b` is ignored:
```
$ echo '{"foo":"bar"}' | hopp-cli post -c js -b '{"other":"data"}' http://example.com

Request body: {"foo":"bar"}
```

But you can still use `-b` by itself:
```
$ hopp-cli post -c js -b '{"other":"data"}' http://example.com

Request body: {"other":"data"}
```