### PR TITLE
Include arbitrary headers with a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ _(optional)_
 |`html`|`text/html`|
 |`xml`|`application/xml`|
 |`plain`|`text/plain`|
+
+### Include Arbitrary Headers
+- `-H` or `--header` may be specified multiple times to include headers with the request.
+- Example:
+  - `hopp-cli get -H 'X-Api-Key: foobar' -H 'X-Api-Secret: super_secret' https://example.com/api/v1/accounts`

--- a/cli.go
+++ b/cli.go
@@ -35,6 +35,10 @@ func main() {
 			Name:  "p",
 			Usage: "Add the Password",
 		},
+		cli.StringSliceFlag{
+			Name:  "header, H",
+			Usage: "Header to pass with the request. Can be used multiple times.",
+		},
 	}
 	genFlags := []cli.Flag{
 		cli.IntFlag{
@@ -61,12 +65,16 @@ func main() {
 			Usage: "Add the Password",
 		},
 		cli.StringFlag{
-			Name:  "ctype, c", //Content Type Flag
+			Name:  "ctype, c", // Content Type Flag
 			Usage: "Change the Content Type",
 		},
 		cli.StringFlag{
 			Name:  "body, b",
 			Usage: "Body of the Post Request",
+		},
+		cli.StringSliceFlag{
+			Name:  "header, H",
+			Usage: "Header to pass with the request. Can be used multiple times.",
 		},
 	}
 	app.Commands = []cli.Command{

--- a/methods/basic.go
+++ b/methods/basic.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -26,6 +27,12 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 		var bearer = "Bearer " + c.String("token")
 		req.Header.Add("Authorization", bearer)
 	}
+
+	for _, h := range c.StringSlice("header") {
+		kv := strings.Split(h, ": ")
+		req.Header.Add(kv[0], kv[1])
+	}
+
 	if c.String("u") != "" && c.String("p") != "" {
 		un := c.String("u")
 		pw := c.String("p")

--- a/methods/get.go
+++ b/methods/get.go
@@ -3,11 +3,12 @@ package methods
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/urfave/cli"
 )
 
-//Getbasic sends a simple GET request to the url with any potential parameters like Tokens or Basic Auth
+// Getbasic sends a simple GET request to the url with any potential parameters like Tokens or Basic Auth
 func Getbasic(c *cli.Context) (string, error) {
 	var url, err = checkURL(c.Args().Get(0))
 	if err != nil {
@@ -27,6 +28,11 @@ func Getbasic(c *cli.Context) (string, error) {
 		un := c.String("u")
 		pw := c.String("p")
 		req.Header.Add("Authorization", "Basic "+basicAuth(un, pw))
+	}
+
+	for _, h := range c.StringSlice("header") {
+		kv := strings.Split(h, ": ")
+		req.Header.Add(kv[0], kv[1])
 	}
 
 	client := getHTTPClient()


### PR DESCRIPTION
This allows any arbitrary header to be set for a given request. As an example, many HTTP APIs, particularly commercial HTTP APIs, require opaque authentication tokens to be set in the headers, instead of the more familiar bearer tokens.

Added the following flag:
* `-H`
* `--header`

Must be in the text format `key: value` and can be specified multiple times to include multiple headers.

Example request:
```
$ hopp-cli get -H 'X-Api-Key: foobar' -H 'X-Api-Secret: super_secret' https://example.com/api/v1/accounts
```