### PR TITLE
Implemented request-body data insertion through text-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $ hopp-cli post -c js http://example.com <myrequest.json
 
 ### Providing a Request Body via text-editor
 
-In addition to providing request body via `-b/ --body` flag and stdin,
+In addition to providing request body via `-b / --body` flag and stdin,
 you can also use `-e / --editor` flag which opens default text-editor in your system.
 
 **Example:**
@@ -158,10 +158,10 @@ you can also use `-e / --editor` flag which opens default text-editor in your sy
 $ hopp-cli post https://reqres.in/api/users/2 -c js -e
 ```
 
-It will preferrably open editor based on `$EDITOR` env.
+It will preferrably open editor based on `$EDITOR` environment variable.
 
 **For example:**
-In your environment variable if `EDITOR=code` it will open VSCode for request-body input. Else, it will use default editor value based on OS.
+If the environment variable is `$EDITOR=code` it will open VSCode for request-body input. Else, it will use default editor value based on the OS.
 
 | OS      | Default Editor |
 | ------- | -------------- |

--- a/README.md
+++ b/README.md
@@ -146,3 +146,25 @@ $ cat myrequest.json
 
 $ hopp-cli post -c js http://example.com <myrequest.json
 ```
+
+### Providing a Request Body via text-editor
+
+In addition to providing request body via `-b/ --body` flag and stdin,
+you can also use `-e / --editor` flag which opens default text-editor in your system.
+
+**Example:**
+
+```shell
+$ hopp-cli post https://reqres.in/api/users/2 -c js -e
+```
+
+It will preferrably open editor based on `$EDITOR` env.
+
+**For example:**
+In your environment variable if `EDITOR=code` it will open VSCode for request-body input. Else, it will use default editor value based on OS.
+
+| OS      | Default Editor |
+| ------- | -------------- |
+| Linux   | `nano`         |
+| macOS   | `nano`         |
+| Windows | `notepad`      |

--- a/cli.go
+++ b/cli.go
@@ -173,5 +173,5 @@ func main() {
 		l.Println(color.HiRedString("\n%s", err.Error()))
 		os.Exit(1)
 	}
-	fmt.Println(out)
+	fmt.Fprintf(color.Output, out)
 }

--- a/cli.go
+++ b/cli.go
@@ -68,6 +68,10 @@ func main() {
 			Name:  "body, b",
 			Usage: "Body of the Post Request",
 		},
+		cli.BoolFlag{
+			Name:  "editor, e",
+			Usage: "Open editor to insert request body",
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/methods/basic.go
+++ b/methods/basic.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 
@@ -22,10 +23,10 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 	var jsonStr []byte
 
 	if c.Bool("editor") {
-		var path = os.Getenv("EDITOR")
-		var editor string
+		var path string
+		var editor = os.Getenv("EDITOR")
 
-		if path == "" {
+		if editor == "" {
 			// check OS
 			currentOs := runtime.GOOS
 
@@ -35,11 +36,11 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 			} else if currentOs == "windows" {
 				editor = "notepad"
 			}
+		}
 
-			path, err = exec.LookPath(editor)
-			if err != nil {
-				return "", fmt.Errorf("Unable to locate %s: %w", editor, err)
-			}
+		path, err = exec.LookPath(editor)
+		if err != nil {
+			return "", fmt.Errorf("Unable to locate %s: %w", editor, err)
 		}
 
 		// create temp file for writing request body
@@ -62,7 +63,7 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 			return "", fmt.Errorf("Unable to open editor: %w", err)
 		}
 
-		fmt.Println("Waiting for file to close..")
+		color.Yellow("Waiting for file to close..\n\n")
 
 		err = cmd.Wait()
 		if err != nil {

--- a/methods/basic.go
+++ b/methods/basic.go
@@ -29,46 +29,42 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 		// check OS
 		currentOs := runtime.GOOS
 
-		// based on OS find path for default editor
+		// based on OS find assign default editor
 		if currentOs == "linux" || currentOs == "darwin" {
 			editor = "nano"
-			path, err = exec.LookPath(editor)
 		} else if currentOs == "windows" {
 			editor = "notepad"
-			path, err = exec.LookPath(editor)
 		}
 
-		fmt.Println(string(path))
+		path, err = exec.LookPath(editor)
 		if err != nil {
-			return "", fmt.Errorf("Error %s while locating %s!!", path, editor)
+			return "", fmt.Errorf("Unable to locate %s at %s", editor, path)
 		}
 
 		// create temp file for writing request body
-
 		tempFile, err := ioutil.TempFile("", "HOPP-CLI-REQUEST*.txt")
-
 		if err != nil {
 			return "", fmt.Errorf("Unable to create temp file: %s\n%s", tempFile.Name(), err)
 		}
 
-		// open temp file in selected editor and wait until closed
 		tempFileName := string(tempFile.Name())
+		tempFile.Close()
+
+		// open temp file in selected editor and wait until closed
 		cmd := exec.Command(path, tempFileName)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 
 		err = cmd.Start()
-
 		if err != nil {
 			return "", fmt.Errorf("Unable to open editor: %s", err)
 		}
 
-		color.Yellow("Waiting for file to close..\n")
+		color.Yellow("Waiting for file to close..\n\n")
 		cmd.Wait()
 
 		// read temp file contents
 		fileData, err := ioutil.ReadFile(tempFileName)
-
 		if err != nil {
 			return "", fmt.Errorf("Error reading file: %s", err)
 		}

--- a/methods/basic.go
+++ b/methods/basic.go
@@ -58,15 +58,13 @@ func BasicRequestWithBody(c *cli.Context, method string) (string, error) {
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 
-		err = cmd.Start()
-		if err != nil {
+		if err := cmd.Start(); err != nil {
 			return "", fmt.Errorf("Unable to open editor: %w", err)
 		}
 
 		color.Yellow("Waiting for file to close..\n\n")
 
-		err = cmd.Wait()
-		if err != nil {
+		if err := cmd.Wait(); err != nil {
 			return "", fmt.Errorf("Error waiting for file: %w", err)
 		}
 


### PR DESCRIPTION
Implements #41 

For methods with request body, this update now allows user to insert request body data through editor.
For example:
- Currently, this is what we do to add request body:
`$ hopp-cli post https://reqres.in/api/users/2 -c js -b '{"name": "morp","job": "zion resident"}'`
- Now, we can also use **-e** flag, indicating request data insertion through text-editor:
`$ hopp-cli post https://reqres.in/api/users/2 -c js -e`
