### PR TITLE
Scoop install alternative for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,24 @@ $ sh -c "$(curl -sL https://git.io/getpwcli)"
 
 - Clone the repo
 
-```
+```shell
 $ git clone https://github.com/hoppscotch/hopp-cli.git
 ```
 
 - Build and install
 
-```
+```shell
 $ make
-
 $ sudo make install
 ```
 
 ### From Binary
 
-- You can find the Binaries in Gzipped form from the [Releases](https://github.com/athul/pwcli/releases) page
-  **Supports**
-- Linux(x64,x86)
-- Mac(x64)
-- Windows(x64,x86)
+- You can download prebuilt binaries from the [Releases](https://github.com/athul/pwcli/releases) page.
+- **Supported platforms**:
+  - Linux (x64, x86)
+  - Mac (x64)
+  - Windows (x64, x86)
 
 > **IMPORTANT: Not tested on Windows, please leave your feedback/bugs in the Issues section**
 
@@ -49,7 +48,11 @@ hopp-cli-git  | https://aur.archlinux.org/packages/hopp-cli-git/  | Compiled fro
 
 ### Homebrew
 
-Install by `brew install athul/tap/hopp-cli`
+Install by
+
+```shell
+brew install athul/tap/hopp-cli
+```
 
 ### Windows
 
@@ -57,7 +60,7 @@ You can download pre-built binaries from the [Releases](https://github.com/hopps
 
 Alternatively, you can install `hopp-cli` via [Scoop](https://scoop.sh/):
 
-```
+```shell
 scoop install hopp-cli
 ```
 
@@ -67,8 +70,8 @@ Putting Simply: **Just pass the URL to the request method**
 
 ### Basic Commands
 
-- GET : `$ hopp-cli get <url> `
-- POST: `$ hopp-cli post <url> `
+- GET : `$ hopp-cli get <url>`
+- POST: `$ hopp-cli post <url>`
 - PATCH: `$ hopp-cli patch <url>`
 - PUT : `$ hopp-cli put <url>`
 - DELETE: `$ hopp-cli delete <url>`
@@ -77,7 +80,6 @@ Example for a POST request:
 
 ```shell
 $ hopp-cli post https://reqres.in/api/users/2 -c js -b '{"name": "morp","job": "zion resident"}'
-
 ```
 
 ### Extra Commands
@@ -85,19 +87,31 @@ $ hopp-cli post https://reqres.in/api/users/2 -c js -b '{"name": "morp","job": "
 - `send` for testing multiple endpoints
 - `gen` for generating API docs from Collection
 
-**SEND**: This can be used to test multiple endpoints from the `hoppscotch-collection.json` file.
+#### SEND
+
+This can be used to test multiple endpoints from the `hoppscotch-collection.json` file.
 
 > The output will only be the `statuscode`
 
-Example : `hopp-cli send <PATH to hoppscotch collection.json>`
+Example:
 
-Sample Output:
-![](/assets/send.png)
+```shell
+$ hopp-cli send <PATH to hoppscotch-collection.json>
+```
 
----
+Sample output:
 
-**GEN**: Gen command Generates the API Documentation from  `hoppscotch-collection.json` file and serves it as a Static Page on port `1341`
-Example: `hopp-cli gen <PATH to hoppscotch collection.json>`
+![send-output](/assets/send.png)
+
+#### GEN
+
+The `gen` command generates the API documentation from `hoppscotch-collection.json` file and serves it as a static page on port `1341`.
+
+Example:
+
+```shell
+$ hopp-cli gen <PATH to hoppscotch-collection.json>
+```
 
 Sample Hosted site: https://hopp-docsify.surge.sh/
 
@@ -116,10 +130,9 @@ _(optional)_
 - `-u` for the `Username` in Basic Auth
 - `-p` for the `password` in Basic Auth
 
-### There are 2 flags especially for the data management requests like POST,PUT,PATCH and DELETE
+### There are 2 flags especially for the data management requests like POST, PUT, PATCH and DELETE
 
 - `-c` or `--ctype` for the _Content Type_
-
 - `-b` or `--body` for the Data Body, this can be of json, html or plain text based on the request.
 
 > Enclose the body in Single Quotes(\')
@@ -134,20 +147,28 @@ _(optional)_
 |`plain`|`text/plain`|
 
 ### Include Arbitrary Headers
+
 - `-H` or `--header` may be specified multiple times to include headers with the request.
-- Example:
-  - `hopp-cli get -H 'X-Api-Key: foobar' -H 'X-Api-Secret: super_secret' https://example.com/api/v1/accounts`
+
+Example:
+
+```shell
+$ hopp-cli get -H 'X-Api-Key: foobar' -H 'X-Api-Secret: super_secret' https://example.com/api/v1/accounts
+```
 
 ### Providing a Request Body via stdin
 
-In addition to `-b`/`--body`, you may provide a request body via stdin.
+In addition to `-b`/`--body`, you may provide a request body via stdin.\
 If you combine this method with the `-b` flag, the body provided with `-b` will be ignored.
 
 **Example with Pipes**
+
 ```shell
 $ echo '{"foo":"bar"}' | hopp-cli post -c js http://example.com
 ```
+
 **Example with Redirection**
+
 ```shell
 $ cat myrequest.json
 {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ sudo make install
 
 ### From Binary
 
-- You can download prebuilt binaries from the [Releases](https://github.com/athul/pwcli/releases) page.
+- You can download prebuilt binaries from the [Releases](https://github.com/hoppscotch/hopp-cli/releases) page.
 - **Supported platforms**:
   - Linux (x64, x86)
   - Mac (x64)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ hopp-cli-git  | https://aur.archlinux.org/packages/hopp-cli-git/  | Compiled fro
 
 Install by `brew install athul/tap/hopp-cli`
 
+### Windows
+
+You can download pre-built binaries from the [Releases](https://github.com/hoppscotch/hopp-cli/releases) page.
+
+Alternatively, you can install `hopp-cli` via [Scoop](https://scoop.sh/):
+
+```
+scoop install hopp-cli
+```
+
 ## Usages
 
 Putting Simply: **Just pass the URL to the request method**


### PR DESCRIPTION
- Add installation option via Scoop for Windows (added as ScoopInstaller/Main#3094).
- Minor formatting updates across the Readme.