### PR TITLE
Added arm64 support for all OS fixes issue #46

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,16 @@ builds:
     goarch:
       - 386
       - amd64
+      - arm64
+    targets:
+      - linux_amd64
+      - linux_arm64
+      - linux_386
+      - windows_amd64
+      - windows_arm64
+      - windows_386
+      - darwin_amd64
+      - darwin_arm64
     hooks:
       post: make pack-releases
     ignore:


### PR DESCRIPTION
I have also added targets option as below:
```
    targets:
      - linux_amd64
      - linux_arm64
      - linux_386
      - windows_amd64
      - windows_arm64
      - windows_386
      - darwin_amd64
      - darwin_arm64
```
Removing the unwanted os configuration will stop making it's binaries